### PR TITLE
23 view users

### DIFF
--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -40,5 +40,10 @@ namespace Tabloid.Controllers
                 new { email = userProfile.Email },
                 userProfile);
         }
+        [HttpGet]
+        public IActionResult GetAll()
+        {
+            return Ok(_userRepository.GetAll());
+        }
     }
 }

--- a/Tabloid/Repositories/IUserRepository.cs
+++ b/Tabloid/Repositories/IUserRepository.cs
@@ -1,4 +1,5 @@
-﻿using Tabloid.Models;
+﻿using System.Collections.Generic;
+using Tabloid.Models;
 
 namespace Tabloid.Repositories
 {
@@ -6,5 +7,6 @@ namespace Tabloid.Repositories
     {
         void Add(UserProfile userProfile);
         UserProfile GetByEmail(string email);
+        List<UserProfile> GetAll();
     }
 }

--- a/Tabloid/Repositories/UserRepository.cs
+++ b/Tabloid/Repositories/UserRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
 using Tabloid.Models;
 using Tabloid.Utils;
 
@@ -77,6 +78,47 @@ namespace Tabloid.Repositories
                     DbUtils.AddParameter(cmd, "@UserTypeId", userProfile.UserTypeId);
 
                     userProfile.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+        public List<UserProfile> GetAll()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            Select u.Id, u.FirstName, u.LastName, u.DisplayName, u.UserTypeId,
+                            ut.Id, ut.Name
+                            From UserProfile u
+                                Left Join UserType ut ON u.UserTypeId = ut.Id
+                            Order By u.DisplayName";
+
+                    var reader = cmd.ExecuteReader();
+
+                    var users = new List<UserProfile>();
+                    while (reader.Read())
+                    {
+                        users.Add(new UserProfile()
+                        {
+                            Id = DbUtils.GetInt(reader, "Id"),
+                            FirstName = DbUtils.GetString(reader, "FirstName"),
+                            LastName = DbUtils.GetString(reader, "LastName"),
+                            DisplayName = DbUtils.GetString(reader, "DisplayName"),
+                            UserTypeId = DbUtils.GetInt(reader, "UserTypeId"),
+                            UserType = new UserType()
+                            {
+                                Id = DbUtils.GetInt(reader, "Id"),
+                                Name = DbUtils.GetString(reader, "Name")
+                            },
+                        });
+                    }
+
+                    reader.Close();
+
+                    return users;
+
                 }
             }
         }

--- a/Tabloid/client/src/Managers/UserProfileManager.js
+++ b/Tabloid/client/src/Managers/UserProfileManager.js
@@ -39,7 +39,10 @@
       });
   };
 
-
+export const getAllUsers = () => {
+  return fetch (`https://localhost:5001/api/UserProfile`)
+    .then((res) => res.json())
+}
 
 
 

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -6,6 +6,7 @@ import Tag from "./tags/TagList";
 import TagForm from "./tags/TagForm";
 import TagDelete from "./tags/TagDelete";
 import TagEdit from "./tags/TagEdit";
+import UserProfileList from "./userProfiles/UserProfileList";
 
 export default function ApplicationViews() {
 
@@ -16,6 +17,7 @@ export default function ApplicationViews() {
         <Route path="/createTag" element={<TagForm />} />
         <Route path="/deleteTag/:id" element={<TagDelete />} />
         <Route path="/editTag/:id" element={<TagEdit />} />
+        <Route path="/users" element={<UserProfileList />} />
 
 
         <Route path="/posts" element={ <PostList /> } />

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -34,6 +34,9 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
                 <NavItem>
                   <NavLink tag={RRNavLink} to="/tag">Tag Management</NavLink>
                 </NavItem>
+                <NavItem>
+                  <NavLink tag={RRNavLink} to="/users">User Profiles</NavLink>
+                </NavItem>
               </>
             }
           </Nav>

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -29,13 +29,13 @@ export default function Header({ isLoggedIn, setIsLoggedIn }) {
                   <NavLink tag={RRNavLink} to="/">Home</NavLink>
                 </NavItem>
                 <NavItem>
-                  <NavLink tag={RRNavLink} to="/categories">Category Management</NavLink>
-                </NavItem>
-                <NavItem>
                   <NavLink tag={RRNavLink} to="/posts">Posts</NavLink>
                 </NavItem>
                 <NavItem>
                   <NavLink tag={RRNavLink} to="/myposts">My Posts</NavLink>
+                </NavItem>
+                <NavItem>
+                  <NavLink tag={RRNavLink} to="/categories">Category Management</NavLink>
                 </NavItem>
                 <NavItem>
                   <NavLink tag={RRNavLink} to="/tag">Tag Management</NavLink>

--- a/Tabloid/client/src/components/tags/Tag.js
+++ b/Tabloid/client/src/components/tags/Tag.js
@@ -9,7 +9,7 @@ const Tag = ({tag}) => {
   const {id} = useParams();
   const navigate = useNavigate();
     return (
-        <div style={{display:'flex', letterSpacing: '.5px', alignItems: 'center', margin: '45px', borderBottom: '1px solid gray', height: '30px', width: '500px', justifyContent: 'space-between'}}>
+        <div style={{display:'flex', letterSpacing: '.5px', alignItems: 'center', margin: '45px', borderBottom: '1px solid blue', height: '30px', width: '500px', justifyContent: 'space-between'}}>
             <h5 style={{ marginRight: '15px' }}>{tag.name}</h5>
             
         </div>

--- a/Tabloid/client/src/components/userProfiles/UserProfile.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfile.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const UserProfile = ({user}) => {
+    return (
+        <div style={{borderBottom: '2px solid blue', width: '20%'}}>
+            <h5>{user.displayName}</h5>
+            <h6>User Name: {user.firstName} {user.lastName}</h6>
+            {/* <h6>UserType: {user.userType.name}</h6> */}
+        </div>
+    )
+}
+
+export default UserProfile;

--- a/Tabloid/client/src/components/userProfiles/UserProfile.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfile.js
@@ -5,7 +5,7 @@ const UserProfile = ({user}) => {
         <div style={{borderBottom: '2px solid blue', width: '20%'}}>
             <h5>{user.displayName}</h5>
             <h6>User Name: {user.firstName} {user.lastName}</h6>
-            {/* <h6>UserType: {user.userType.name}</h6> */}
+            <h6>UserType: {user.userType.name}</h6>
         </div>
     )
 }

--- a/Tabloid/client/src/components/userProfiles/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileList.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { useEffect } from "react";
+import { useState } from "react";
+import UserProfile from "./UserProfile";
+import { getAllUsers } from "../../Managers/UserProfileManager";
+
+const UserProfileList = () => {
+    const [users, setUsers] = useState([]);
+
+    const getUsers = () => {
+        getAllUsers().then(all => setUsers(all))
+    };
+
+    useEffect (
+    () => {
+        getUsers();
+    }, []);
+    console.log(users)
+    return (<div>
+        <h3 style={{margin: '15px'}}>User Profiles</h3>
+        <div style={{display: 'flex', flexDirection: 'column',margin: '15px'}}>
+            {users.map((u) => (
+                <div style={{margin: '20px'}}>
+                    <UserProfile key={u.id} user={u}/>
+                </div>
+            ))}
+        </div>
+    </div>)
+}
+
+export default UserProfileList;


### PR DESCRIPTION
**Trello Ticket #23**

https://trello.com/c/JmudcaUD/23-23-view-all-user-profiles

Added functionality to view a list of users, each with its display name, full name and user type. 

1.  ApplicationViews.js - users Route added
2. UserProfile.js added
3.  UserProfileList.js added

**Testing Instructions**
1. git add and git commit whatever you're working on on your branch
4. git checkout main
5. git fetch --a
6. git checkout 23ViewUsers
7. If you don't see the most recent version of my files, git pull origin 23ViewUsers
8. If you haven't created the Tabloid database, please do so.
Use this data to fill out tables and columns: [SQL Tables](https://github.com/NewForce-Cohort-6/tabloidfullstack-mashed-potatoes/blob/main/SQL/01_Tabloid_Create_DB.sql)
Use this to seed the database : [SQL SEED DATA](https://github.com/NewForce-Cohort-6/tabloidfullstack-mashed-potatoes/blob/main/SQL/02_Tabloid_Seed_Data.sql)
9. Click the execute with debugger solid green button to launch the app
10. Log into the website using “[foo@bar.com](mailto:foo@bar.com)” if greeted with a login page
11. From the home page, click the “User Profile” option in the navbar
12. The url should change to /users and a list of users should appear, with display name, full name and user type.
